### PR TITLE
HKT-typeclass-FSharp: rst formatting typo

### DIFF
--- a/src/PL/HKT-typeclass-FSharp.rst
+++ b/src/PL/HKT-typeclass-FSharp.rst
@@ -443,7 +443,7 @@ Therefore, we should use :code:`functor<'F>`.
 References and Further Reading
 -----------------------------------------------------------
 
-[1] Haskell ViewPatterns: <https://ghc.haskell.org/trac/ghc/wiki/ViewPatterns
+[1] Haskell ViewPatterns: https://ghc.haskell.org/trac/ghc/wiki/ViewPatterns
 
 [2] Haskell ViewPatterns vs F# Active Patterns: https://mail.haskell.org/pipermail/haskell-cafe/2009-January/053643.html
 


### PR DESCRIPTION
呃，编辑的时候编辑器自动在最后加了一个 `\n`，而 GitHub 的 diff 竟然连这个都显示不出来……